### PR TITLE
Fix missing word in get.html

### DIFF
--- a/get.html
+++ b/get.html
@@ -164,7 +164,7 @@
                         <code>prboom -iwad DOOM2.wad -file THATCHER.wad</code>
                         <br><br>
                         <h3>GZDoom</h3>
-                        For GZDoom, the OS X instructions should apply... but I don't really know! If you are using Linux, you probably know about computers than I do and do not need my help!
+                        For GZDoom, the OS X instructions should apply... but I don't really know! If you are using Linux, you probably know more about computers than I do and do not need my help!
                         <br><br>
                         </p>
                         <br><br>


### PR DESCRIPTION
Missing out a word in the GZDoom instructions for Linux, inserting "more" makes sense in this context